### PR TITLE
feat: Add primality test option for random number

### DIFF
--- a/Random-Number-Gen.ps1
+++ b/Random-Number-Gen.ps1
@@ -113,6 +113,29 @@ function Write-AsciiArtNumber {
     }
     Write-Host ""
 }
+
+function Test-IsPrime {
+    param (
+        [int]$number
+    )
+
+    if ($number -lt 2) {
+        return $false
+    }
+    if ($number -eq 2) {
+        return $true
+    }
+    if ($number % 2 -eq 0) {
+        return $false
+    }
+    for ($i = 3; $i -le [Math]::Sqrt($number); $i += 2) {
+        if ($number % $i -eq 0) {
+            return $false
+        }
+    }
+    return $true
+}
+
 Clear-Host
 Write-AsciiArtBanner -Text "RANDOM NUMBER GENERATOR"
 $minNumber = $null
@@ -144,6 +167,24 @@ while ($maxNumber -eq $null -or -not ($maxInput -match "^\d+$") -or $maxNumber -
 $randomNumber = Get-Random -Minimum $minNumber -Maximum ($maxNumber + 1)
 Write-Host ""
 Write-AsciiArtNumber -Number $randomNumber
+
+$wantsPrimeCheck = Read-Host "Would you like to check if the random number $randomNumber is a prime number? (y/n)"
+
+if ($wantsPrimeCheck -eq 'y' -or $wantsPrimeCheck -eq 'Y') {
+    $isPrimeResult = Test-IsPrime -number $randomNumber
+    if ($isPrimeResult) { # $true is implicit
+        Write-Host "The number $randomNumber is prime!" -ForegroundColor Green
+    }
+    else {
+        Write-Host "The number $randomNumber is not prime." -ForegroundColor Yellow
+    }
+}
+elseif ($wantsPrimeCheck -eq 'n' -or $wantsPrimeCheck -eq 'N') {
+    Write-Host "Okay, no primality check requested. Exiting."
+}
+else {
+    Write-Host "Invalid input. Please enter 'y' or 'n'." -ForegroundColor Yellow
+}
 
 Write-Host "======================================================================" -ForegroundColor Red
 Write-Host "Done!" -ForegroundColor Green


### PR DESCRIPTION
This commit introduces a feature where you are prompted to check if the generated random number is a prime number.

Modifications include:
- Added a prompt asking you (y/n) if you want to perform a primality check.
- Implemented a `Test-IsPrime` function to determine if a given number is prime. This function handles numbers less than 2, the number 2 itself, even numbers, and uses an efficient check for odd divisors up to the square root of the number.
- Integrated the `Test-IsPrime` function into the main script flow, displaying the result if you opt in.
- Handled your input for the prompt, including invalid entries.
- Manually tested with various scenarios including primes, composites, edge cases (0, 1, 2), and different prompt responses.